### PR TITLE
build: remove `experimental.appDir` in next.config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;


### PR DESCRIPTION
i got an error on ga actions
https://github.com/yutakusuno/portfolio-website/actions/runs/6306081058/job/17120593179?pr=195#step:5:30

> App router is available by default now, `experimental.appDir` option can be safely removed.

related PR https://github.com/vercel/next.js/pull/54785